### PR TITLE
FIX: no image, fallback to placeholder

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -42,7 +42,7 @@ const LoggedInView = (props) => {
         <li className="nav-item">
           <Link to={`/@${props.currentUser.username}`} className="nav-link">
             <img
-              src={props.currentUser.image}
+              src={props.currentUser.image || "/placeholder.png"}
               className="user-pic pr-1"
               alt={props.currentUser.username}
             />

--- a/frontend/src/components/Item/Comment.js
+++ b/frontend/src/components/Item/Comment.js
@@ -14,7 +14,7 @@ const Comment = (props) => {
           <div className="d-flex flex-row align-items-center pt-2">
             <Link to={`/@${comment.seller.username}`} className="user-pic mr-2">
               <img
-                src={comment.seller.image}
+                src={comment.seller.image || "/placeholder.png"}
                 className="user-pic rounded-circle"
                 alt={comment.seller.username}
               />

--- a/frontend/src/components/Item/CommentInput.js
+++ b/frontend/src/components/Item/CommentInput.js
@@ -42,7 +42,7 @@ class CommentInput extends React.Component {
         </div>
         <div className="card-footer">
           <img
-            src={this.props.currentUser.image}
+            src={this.props.currentUser.image || "/placeholder.png"}
             className="user-pic mr-2"
             alt={this.props.currentUser.username}
           />

--- a/frontend/src/components/Item/ItemMeta.js
+++ b/frontend/src/components/Item/ItemMeta.js
@@ -8,7 +8,7 @@ const ItemMeta = (props) => {
     <div className="d-flex flex-row align-items-center pt-2">
       <Link to={`/@${item.seller.username}`}>
         <img
-          src={item.seller.image}
+          src={item.seller.image || "/placeholder.png"}
           alt={item.seller.username}
           className="user-pic mr-2"
         />

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || '/placeholder.png'}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />
@@ -48,7 +48,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={item.seller.image || "/placeholder.png"}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -129,7 +129,7 @@ class Profile extends React.Component {
           <div className="row p-4 text-center">
             <div className="user-info col-xs-12 col-md-8 offset-md-2">
               <img
-                src={profile.image}
+                src={profile.image || "/placeholder.png"}
                 className="user-img"
                 alt={profile.username}
               />


### PR DESCRIPTION
## Problem
> It seems that when creating a new product without an image, there are broken images showing up in the product catalog.
## Solution
If the user did not provide any image url, we will fallback to a placeholder image or UI.
<img width="1120" alt="Screenshot 2022-09-19 at 09 47 16" src="https://user-images.githubusercontent.com/36933805/190972215-c250cebb-1d17-40fc-ab9a-f1e8838fd65a.png">

For the fallback image I have used an image already in the repo __/public/placeholder.png__.
If we are required to have user picture I think we should make the image url field required in the Editor for adding a new product.
